### PR TITLE
Fix untappd requiring login and rehash config system

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -15,6 +15,7 @@ import threading
 import urllib.parse
 from bs4 import BeautifulSoup
 from requests_oauthlib import OAuth1Session
+from config import Config
 
 class tcol:
         NORMAL = "\u000f"
@@ -727,13 +728,18 @@ def bash(args):
 
 @command("ut")
 def ut(args):
+    # Search now requires we are logged in
+    cookie = Config.untappd_cookie
     baseurl = "https://www.untappd.com"
     user_agent = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.85 Safari/537.36'}
     if len(args["args"]) == 0:
         return
     query_string = urllib.parse.urlencode({"q":" ".join(args["args"])})
-    r = requests.get(baseurl + "/search?" + query_string, headers=user_agent)
-
+    r = requests.get(
+            baseurl + "/search?" + query_string,
+            headers = user_agent,
+            cookies = {'untappd_user_v2_e': cookie}
+            )
     if r.status_code != 200:
         return
 

--- a/config.json.example
+++ b/config.json.example
@@ -4,5 +4,6 @@
     "bot_nick" : 0,
     "channels" : ["#server", "#test"],
     "password" : 0 ,
-    "prefix" : "."
+    "prefix" : ".",
+    "untappd_cookie" : ""
 }

--- a/config.py
+++ b/config.py
@@ -1,0 +1,25 @@
+import sys
+import json
+import random
+class Config:
+    with open(sys.argv[1], 'r') as data_file:
+        try:
+            config = json.loads(data_file.read())
+        except ValueError:
+            print('Please provide valid config')
+            exit(1)
+    try:
+        server = config["server"]
+        port = config["port"]
+        channels = config["channels"]
+        if config["bot_nick"]:
+            bot_nick = config["bot_nick"]
+        else:
+            bot_nick = "BOT" + str(random.randint(1, 9999))
+        password = config["password"]
+        prefix = config["prefix"]
+        untappd_cookie = config["untappd_cookie"]
+
+    except KeyError:
+        print('Please provide valid config')
+        exit(1)

--- a/irc.py
+++ b/irc.py
@@ -6,6 +6,7 @@ import random
 import itertools
 import json
 import threading
+from config import Config
 from commands import get_command
 
 
@@ -13,25 +14,12 @@ if len(sys.argv) < 2:
     print("Usage: irc.py [config.json]")
     exit(1)
 #load config from json, check if everything is alright
-with open(sys.argv[1], 'r') as data_file:
-    try:
-        config = json.loads(data_file.read())
-    except ValueError:
-        print('Please provide valid config')
-        exit(1)
-try:
-    server = config["server"]
-    port = config["port"]
-    channel_list = config["channels"]
-    if config["bot_nick"]:
-        botnick = config["bot_nick"]
-    else:
-        botnick = "BOT" + str(random.randint(1, 9999))
-    password = config["password"]
-    commandprefix = config["prefix"]
-except KeyError:
-    print('Please provide valid config')
-    exit(1)
+server = Config.server
+port = Config.port
+channel_list = Config.channels
+botnick = Config.bot_nick
+password = Config.password
+commandprefix = Config.prefix
 
 def sendmsg(recipient, msg):
     """Sends a message."""
@@ -195,7 +183,7 @@ while True:
         elif any(channel in ircmsg for channel in channel_list):
             try:
                 args = parsemsg(str(ircmsg))
-                args['config'] = config
+                args['config'] = Config.config
 
                 channel = args['channel']
                 if "|" in args["args"]:


### PR DESCRIPTION
Untappd now requires you be logged in in order to search. No problem,
just add a config option for supplying it with a valid login cookie. Oh
but you can't access the config variables, even if they're global?
Config is now a class through which anything can access the
configuration directives. Previously, this worked by passing them in the
arg[] array, but the Class way is better I think.